### PR TITLE
Makefile and compiler warning fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-CC=gcc
-CFLAGS=-I. -Ipipe_elements/. -Iinput_elements/. -Wno-pointer-sign -Wno-variadic-macros -O0 -g
-LIBS=-lyajl -lcurl -lssl -lcrypto
+CC?=gcc
+CFLAGS+=-I. -Ipipe_elements/. -Iinput_elements/. -Wno-pointer-sign -Wno-variadic-macros -O0 -g
+LIBS+=-lyajl -lcurl -lssl -lcrypto
+
+all: mlogc-ng
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS) 
@@ -17,7 +19,7 @@ OBJS = \
        pipe_elements/send_to_server.o
 
 mlogc-ng: $(OBJS)
-	gcc -o $@ $^ $(CFLAGS) $(LIBS)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 clean:
-	rm *.o pipe_elements/*.o input_elements/*.o mlogc-ng
+	rm -f *.o pipe_elements/*.o input_elements/*.o mlogc-ng

--- a/input_elements/filesystem-walker.c
+++ b/input_elements/filesystem-walker.c
@@ -87,7 +87,7 @@ failed:
     return res;
 }
 
-int open_directory_recursive(unsigned char *path, void *audit_log_entry_cb,
+int open_directory_recursive(const unsigned char *path, void *audit_log_entry_cb,
         struct read_from_filesystem_config_t *conf)
 {
     DIR *d;

--- a/input_elements/filesystem-walker.h
+++ b/input_elements/filesystem-walker.h
@@ -2,7 +2,10 @@
 #ifndef __FILESYSTEM_WALKER_H__
 #define __FILESYSTEM_WALKER_H__
 
+#include "read_from_filesystem.h"
+
 int inspect_file(unsigned char *, void *);
-int open_directory_recursive(unsigned char *, void *);
+int open_directory_recursive(const unsigned char *, void *,
+	struct read_from_filesystem_config_t *);
 
 #endif

--- a/input_elements/input_batch.c
+++ b/input_elements/input_batch.c
@@ -303,7 +303,7 @@ int load_buffer(char *buf, struct audit_log_entry_t *audit_log)
 
     char number[20];
     memset(number, '\0', 20);
-    snprintf(number, 20, "%d", strlen(buf));
+    snprintf(number, 20, "%lu", strlen(buf));
 
     audit_log->mark = mark;
     audit_log->buf = buf;

--- a/input_elements/read_from_filesystem.c
+++ b/input_elements/read_from_filesystem.c
@@ -8,6 +8,7 @@
 #include "configuration.h"
 
 #include "read_from_filesystem.h"
+#include "filesystem-walker.h"
 
 
 int read_from_filesystem_call_entry_cb(struct audit_log_entry_t *audit_log,

--- a/pipe_elements/persistence.c
+++ b/pipe_elements/persistence.c
@@ -8,7 +8,7 @@
 #include "persistence.h"
 #include "pipeline.h"
 
-inline int persistence_file_exists(const char *file)
+int persistence_file_exists(const char *file)
 {
     struct stat buffer;
     return (stat (file, &buffer) == 0);

--- a/pipeline.h
+++ b/pipeline.h
@@ -24,5 +24,7 @@ struct pipeline_t {
 
 struct pipeline_element_t *create_pipe_element(const char *, const yajl_val *,
 		struct pipeline_t *);
+int add_pipe_element(struct pipeline_t *, struct pipeline_element_t *);
+int pipeline_process(struct pipeline_t *, struct audit_log_entry_t *);
 
 #endif


### PR DESCRIPTION
This fixes some warnings and an error when compiling, where functions are not declared or have the wrong declaration.

In addition it updates the makefile to respect CC, CFLAGS and LIBS from the environment by adding to them instead of overwriting them. This makes it easier for us to create a FreeBSD port for mlogc-ng.